### PR TITLE
Add .gitignore for generated configs and data dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Generated service config
+services-config.json
+
+# Generated Docker Compose files
+*.yml
+
+# Service data directories
+postgres_data/
+.n8n_data/
+.redis_data/
+directus/
+.sessions/
+backups/
+
+# Backup directories with timestamps
+*_backup_*/
+
+# IDE and editor folders
+.idea/
+.vscode/
+
+# Editor swap and temporary files
+*~
+*.swp
+*.swo
+*.sw?
+
+# System files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+desktop.ini


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude generated Compose files and service data folders
- ignore `services-config.json`, editor swap files, IDE folders and common OS junk files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d4fb8a608326b7355b64c6ca81db